### PR TITLE
Make address sanitizer optional

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -22,6 +22,7 @@ jobs:
               if: matrix.node == 'Debug'
               run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
             - name: Configure Release
+              working-directory: ${{runner.workspace}}/kronmult/build
               if: matrix.node == 'Release'
               run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -19,9 +19,9 @@ jobs:
               run: cmake -E make_directory build
             - name: Configure
               working-directory: ${{runner.workspace}}/kronmult/build
-              if: matrix.node == 'Debug':
+              if: matrix.node == 'Debug'
                   - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
-              if: matrix.node == 'Release':
+              if: matrix.node == 'Release'
                   - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest]
-                node: [Release, Debug]
+                node: [Release, Sanitized]
         runs-on: ${{matrix.os}}
         steps:
             - name: Clone Repo
@@ -17,13 +17,9 @@ jobs:
             - name: Makedir
               working-directory: ${{runner.workspace}}/kronmult
               run: cmake -E make_directory build
-            - name: Configure Debug
+            - name: Configure
               working-directory: ${{runner.workspace}}/kronmult/build
               if: matrix.node == 'Debug'
-              run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
-            - name: Configure Release
-              working-directory: ${{runner.workspace}}/kronmult/build
-              if: matrix.node == 'Release'
               run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -19,7 +19,10 @@ jobs:
               run: cmake -E make_directory build
             - name: Configure
               working-directory: ${{runner.workspace}}/kronmult/build
-              run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
+              if: matrix.node == 'Debug':
+                  - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
+              if: matrix.node == 'Release':
+                  - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build
               run: make

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -17,14 +17,13 @@ jobs:
             - name: Makedir
               working-directory: ${{runner.workspace}}/kronmult
               run: cmake -E make_directory build
-            - name: Configure
+            - name: Configure Debug
               working-directory: ${{runner.workspace}}/kronmult/build
               if: matrix.node == 'Debug'
-                  - name: Debug Configure
-                    run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
+              run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
+            - name: Configure Release
               if: matrix.node == 'Release'
-                  - name: Release Configure
-                    run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
+              run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build
               run: make

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -20,9 +20,11 @@ jobs:
             - name: Configure
               working-directory: ${{runner.workspace}}/kronmult/build
               if: matrix.node == 'Debug'
-                  - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
+                  - name: Debug Configure
+                    run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address ../
               if: matrix.node == 'Release'
-                  - run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
+                  - name: Release Configure
+                    run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build
               run: make

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -19,7 +19,6 @@ jobs:
               run: cmake -E make_directory build
             - name: Configure
               working-directory: ${{runner.workspace}}/kronmult/build
-              if: matrix.node == 'Debug'
               run: cmake -DCMAKE_BUILD_TYPE=${{matrix.node}} ../
             - name: Build
               working-directory: ${{runner.workspace}}/kronmult/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,22 +24,22 @@
 #-------------------------------------------------------------------------------
 #  Sanitizer options
 #-------------------------------------------------------------------------------
-#    set (CMAKE_CXX_FLAGS_SANITIZED -fno-omit-frame-pointer)
-#    set (CMAKE_CUDA_FLAGS_SANITIZED -fno-omit-frame-pointer)
-#    set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "")
-#    set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "")
+    set (CMAKE_CXX_FLAGS_SANITIZED -fno-omit-frame-pointer)
+    set (CMAKE_CUDA_FLAGS_SANITIZED -fno-omit-frame-pointer)
+    set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "")
+    set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "")
 
     macro (register_sanitizer_option name default)
         string (TOUPPER ${name} upper_name)
 
         option (SANITIZE_${upper_name} "Enable the ${name} sanitizer" ${default})
 
-#        if (${SANITIZE_${upper_name}})
-#            set (CMAKE_CXX_FLAGS_SANITIZED "${CMAKE_CXX_FLAGS_SANITIZED} -fsanitize=${name}")
-#            set (CMAKE_CUDA_FLAGS_SANITIZED "${CMAKE_CUDA_FLAGS_SANITIZED} -fsanitize=${name}")
-#            set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "${CMAKE_EXE_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
-#            set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "${CMAKE_SHARED_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
-#        endif ()
+        if (${SANITIZE_${upper_name}})
+            set (CMAKE_CXX_FLAGS_SANITIZED "${CMAKE_CXX_FLAGS_SANITIZED} -fsanitize=${name}")
+            set (CMAKE_CUDA_FLAGS_SANITIZED "${CMAKE_CUDA_FLAGS_SANITIZED} -fsanitize=${name}")
+            set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "${CMAKE_EXE_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
+            set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "${CMAKE_SHARED_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
+        endif ()
     endmacro ()
 
     register_sanitizer_option (address ON)
@@ -113,25 +113,8 @@
 
     target_compile_options (kron
                             PUBLIC
-                            $<$<CONFIG:Sanitized>:-fno-omit-frame-pointer
-                                                  $<$<BOOL:${SANITIZE_ADDRESS}>:-fsanitize=address>
-                                                  $<$<BOOL:${SANITIZE_THREAD}>:-fsanitize=thread>
-                                                  $<$<BOOL:${SANITIZE_MEMORY}>:-fsanitize=memory>
-                                                  $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
-                                                  $<$<BOOL:${SANITIZE_LEAK}>:-fsanitize=undefined>
-                            >
                             $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wpedantic>
                             $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options -fPIC --keep-device-functions>
-    )
-    target_link_options (kron
-                         PUBLIC
-                         $<$<CONFIG:Sanitized>:-fno-omit-frame-pointer
-                                               $<$<BOOL:${SANITIZE_ADDRESS}>:-fsanitize=address>
-                                               $<$<BOOL:${SANITIZE_THREAD}>:-fsanitize=thread>
-                                               $<$<BOOL:${SANITIZE_MEMORY}>:-fsanitize=memory>
-                                               $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
-                                               $<$<BOOL:${SANITIZE_LEAK}>:-fsanitize=undefined>
-                         >
     )
 
     target_compile_definitions (kron

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,13 +85,8 @@
 
     target_compile_options (kron
                             PUBLIC
-                            $<$<CONFIG:Debug>:-fsanitize=address>
                             $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wpedantic>
                             $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options -fPIC --keep-device-functions>
-    )
-    target_link_options (kron
-                         PUBLIC
-                         $<$<CONFIG:Debug>:-fsanitize=address>
     )
 
     target_compile_definitions (kron

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@
     endmacro ()
 
     register_sanitizer_option (address ON)
-    register_sanitizer_option (leak ON)
+    register_sanitizer_option (leak OFF)
     register_sanitizer_option (memory OFF)
     register_sanitizer_option (thread OFF)
     register_sanitizer_option (undefined ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,35 @@
                   Release
                   MinSizeRel
                   RelWithDebInfo
+                  Sanitized
     )
+
+#-------------------------------------------------------------------------------
+#  Sanitizer options
+#-------------------------------------------------------------------------------
+#    set (CMAKE_CXX_FLAGS_SANITIZED -fno-omit-frame-pointer)
+#    set (CMAKE_CUDA_FLAGS_SANITIZED -fno-omit-frame-pointer)
+#    set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "")
+#    set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "")
+
+    macro (register_sanitizer_option name default)
+        string (TOUPPER ${name} upper_name)
+
+        option (SANITIZE_${upper_name} "Enable the ${name} sanitizer" ${default})
+
+#        if (${SANITIZE_${upper_name}})
+#            set (CMAKE_CXX_FLAGS_SANITIZED "${CMAKE_CXX_FLAGS_SANITIZED} -fsanitize=${name}")
+#            set (CMAKE_CUDA_FLAGS_SANITIZED "${CMAKE_CUDA_FLAGS_SANITIZED} -fsanitize=${name}")
+#            set (CMAKE_EXE_LINKER_FLAGS_SANITIZED "${CMAKE_EXE_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
+#            set (CMAKE_SHARED_LINKER_FLAGS_SANITIZED "${CMAKE_SHARED_LINKER_FLAGS_SANITIZED} -fsanitize=${name}")
+#        endif ()
+    endmacro ()
+
+    register_sanitizer_option (address ON)
+    register_sanitizer_option (leak ON)
+    register_sanitizer_option (memory OFF)
+    register_sanitizer_option (thread OFF)
+    register_sanitizer_option (undefined ON)
 
 #-------------------------------------------------------------------------------
 #  Define a macro function to set a targets source files to the CUDA language.
@@ -85,8 +113,25 @@
 
     target_compile_options (kron
                             PUBLIC
+                            $<$<CONFIG:Sanitized>:-fno-omit-frame-pointer
+                                                  $<$<BOOL:${SANITIZE_ADDRESS}>:-fsanitize=address>
+                                                  $<$<BOOL:${SANITIZE_THREAD}>:-fsanitize=thread>
+                                                  $<$<BOOL:${SANITIZE_MEMORY}>:-fsanitize=memory>
+                                                  $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
+                                                  $<$<BOOL:${SANITIZE_LEAK}>:-fsanitize=undefined>
+                            >
                             $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wpedantic>
                             $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options -fPIC --keep-device-functions>
+    )
+    target_link_options (kron
+                         PUBLIC
+                         $<$<CONFIG:Sanitized>:-fno-omit-frame-pointer
+                                               $<$<BOOL:${SANITIZE_ADDRESS}>:-fsanitize=address>
+                                               $<$<BOOL:${SANITIZE_THREAD}>:-fsanitize=thread>
+                                               $<$<BOOL:${SANITIZE_MEMORY}>:-fsanitize=memory>
+                                               $<$<BOOL:${SANITIZE_UNDEFINED}>:-fsanitize=undefined>
+                                               $<$<BOOL:${SANITIZE_LEAK}>:-fsanitize=undefined>
+                         >
     )
 
     target_compile_definitions (kron


### PR DESCRIPTION
This changes the way the address sanitizer is run in the CI tests. Previously, the address sanitizer was run by default for any debug build. This change leaves it to the end user to configure but still allows the CI tests to run this under the debug builds.