### PR TITLE
Add expect macro to avoid warnings in release build

### DIFF
--- a/kgemm_nn.hpp
+++ b/kgemm_nn.hpp
@@ -40,9 +40,9 @@ void kgemm_nn( int const mm, int const nn, int const kk,
 	int constexpr warpsize = 32;
         int const nthreads = blockDim.x; 
 
-        assert( blockDim.y == 1);
-        assert( blockDim.z == 1);
-        assert( (nthreads % warpsize) == 0);
+        expect( blockDim.y == 1);
+        expect( blockDim.z == 1);
+        expect( (nthreads % warpsize) == 0);
 
         // -----------------------------------------
         // reorganize threads as nx_threads by ny_threads
@@ -69,10 +69,10 @@ void kgemm_nn( int const mm, int const nn, int const kk,
 	int const ij_size = 1;
 #endif
 
-        assert( ix_start >= 1);
-        assert( iy_start >= 1);
-        assert( ix_size >= 1 );
-        assert( iy_size >= 1 );
+        expect( ix_start >= 1);
+        expect( iy_start >= 1);
+        expect( ix_size >= 1 );
+        expect( iy_size >= 1 );
 
 
         //  ------------------------------------

--- a/kgemm_nn_batched.hpp
+++ b/kgemm_nn_batched.hpp
@@ -53,8 +53,8 @@ void kgemm_nn_batched( int const mm, int const nn, int const kk,
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
 
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kgemm_nt.hpp
+++ b/kgemm_nt.hpp
@@ -40,15 +40,15 @@ void kgemm_nt( int const mm, int const nn, int const kk,
 	int constexpr warpsize = 32;
         int const nthreads = blockDim.x; 
 
-        assert( blockDim.y == 1);
-        assert( blockDim.z == 1);
+        expect( blockDim.y == 1);
+        expect( blockDim.z == 1);
 
         // -----------------------------------------
         // reorganize threads as nx_threads by ny_threads
         // -----------------------------------------
         int const nx_threads = warpsize;
         int const ny_threads = max(1,nthreads/nx_threads);
-        assert( (nthreads % warpsize) == 0);
+        expect( (nthreads % warpsize) == 0);
 
         int const ix_start = ( threadIdx.x % nx_threads ) + 1;
         int const iy_start = (threadIdx.x/nx_threads) + 1;
@@ -70,10 +70,10 @@ void kgemm_nt( int const mm, int const nn, int const kk,
 	int const ij_size = 1;
 #endif
 
-        assert( ix_start >= 1);
-        assert( iy_start >= 1);
-        assert( ix_size >= 1 );
-        assert( iy_size >= 1 );
+        expect( ix_start >= 1);
+        expect( iy_start >= 1);
+        expect( ix_size >= 1 );
+        expect( iy_size >= 1 );
 
 
         //  ------------------------------------

--- a/kgemm_nt_batched.hpp
+++ b/kgemm_nt_batched.hpp
@@ -50,8 +50,8 @@ void kgemm_nt_batched( int const mm, int const nn, int const kk,
 #ifdef USE_GPU
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kroncommon.hpp
+++ b/kroncommon.hpp
@@ -25,6 +25,14 @@
 #include <algorithm>
 #include <vector>
 
+// simple layer over assert to prevent unused variable warnings when
+// expects disabled
+#ifndef NDEBUG
+#define expect(cond) assert(cond)
+#else
+#define expect(cond) ((void)(cond))
+#endif
+
 #ifndef USE_GPU
 
 static inline

--- a/kronmult1_batched.hpp
+++ b/kronmult1_batched.hpp
@@ -33,8 +33,8 @@ void kronmult1_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult1_pbatched.hpp
+++ b/kronmult1_pbatched.hpp
@@ -35,8 +35,8 @@ void kronmult1_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult1_xbatched.hpp
+++ b/kronmult1_xbatched.hpp
@@ -36,8 +36,8 @@ void kronmult1_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult2_batched.hpp
+++ b/kronmult2_batched.hpp
@@ -33,8 +33,8 @@ void kronmult2_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult2_pbatched.hpp
+++ b/kronmult2_pbatched.hpp
@@ -39,8 +39,8 @@ void kronmult2_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult2_xbatched.hpp
+++ b/kronmult2_xbatched.hpp
@@ -40,8 +40,8 @@ void kronmult2_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult3_batched.hpp
+++ b/kronmult3_batched.hpp
@@ -33,8 +33,8 @@ void kronmult3_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult3_pbatched.hpp
+++ b/kronmult3_pbatched.hpp
@@ -39,8 +39,8 @@ void kronmult3_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult3_xbatched.hpp
+++ b/kronmult3_xbatched.hpp
@@ -40,8 +40,8 @@ void kronmult3_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult4_batched.hpp
+++ b/kronmult4_batched.hpp
@@ -33,8 +33,8 @@ void kronmult4_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult4_pbatched.hpp
+++ b/kronmult4_pbatched.hpp
@@ -39,8 +39,8 @@ void kronmult4_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult4_xbatched.hpp
+++ b/kronmult4_xbatched.hpp
@@ -40,8 +40,8 @@ void kronmult4_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult5_batched.hpp
+++ b/kronmult5_batched.hpp
@@ -33,8 +33,8 @@ void kronmult5_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1 );
-        assert( gridDim.z == 1 );
+        expect( gridDim.y == 1 );
+        expect( gridDim.z == 1 );
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult5_pbatched.hpp
+++ b/kronmult5_pbatched.hpp
@@ -39,8 +39,8 @@ void kronmult5_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult5_xbatched.hpp
+++ b/kronmult5_xbatched.hpp
@@ -40,8 +40,8 @@ void kronmult5_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult6_batched.hpp
+++ b/kronmult6_batched.hpp
@@ -33,8 +33,8 @@ void kronmult6_batched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult6_pbatched.hpp
+++ b/kronmult6_pbatched.hpp
@@ -39,8 +39,8 @@ void kronmult6_pbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/kronmult6_xbatched.hpp
+++ b/kronmult6_xbatched.hpp
@@ -40,8 +40,8 @@ void kronmult6_xbatched(
         // -------------------------------------------
         int const iz_start = blockIdx.x + 1;
         int const iz_size =  gridDim.x;
-        assert( gridDim.y == 1);
-        assert( gridDim.z == 1);
+        expect( gridDim.y == 1);
+        expect( gridDim.z == 1);
 #else
         int const iz_start = 1;
         int const iz_size = 1;

--- a/test_kgemm_nn_batched.cpp
+++ b/test_kgemm_nn_batched.cpp
@@ -22,7 +22,7 @@ void host2gpu( void *dest, void *src, size_t nbytes )
                                         src, 
                                         nbytes,  
                                         cudaMemcpyHostToDevice );
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -36,7 +36,7 @@ void gpu2host( void * dest, void * src, size_t nbytes )
                                         src,
                                         nbytes,
                                         cudaMemcpyDeviceToHost);
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -48,11 +48,11 @@ void *myalloc( size_t const nbytes ) {
               void *devPtr = nullptr;
 #ifdef USE_GPU
               cudaError_t istat = cudaMalloc( &devPtr, nbytes );
-              assert( istat == cudaSuccess );
+              expect( istat == cudaSuccess );
 #else
               devPtr = malloc( nbytes );
 #endif
-              assert( devPtr != nullptr );
+              expect( devPtr != nullptr );
               return(devPtr);
 }
 
@@ -60,7 +60,7 @@ static inline
 void myfree( void * devPtr ) {
 #ifdef USE_GPU
                 cudaError_t istat = cudaFree( devPtr);
-                assert( istat == cudaSuccess );
+                expect( istat == cudaSuccess );
 #else
                 free( devPtr );
 #endif
@@ -138,9 +138,9 @@ T test_kgemm_nn_batched( int const mm,
                 T * const B_ = new T[ldB*ncolB];
                 T * const C_ = new T[ldC*ncolC];
 
-                assert( A_ != nullptr);
-                assert( B_ != nullptr);
-                assert( C_ != nullptr);
+                expect( A_ != nullptr);
+                expect( B_ != nullptr);
+                expect( C_ != nullptr);
 
                 Aarray_[ibatch] = A_;
                 Barray_[ibatch] = B_;
@@ -210,9 +210,9 @@ T test_kgemm_nn_batched( int const mm,
                 size_t const nbytes_C = sizeof(T)*ldC*ncolC;
                 T *dC = (T *) myalloc( nbytes_C );;
 
-                assert( dA != nullptr );
-                assert( dB != nullptr );
-                assert( dC != nullptr );
+                expect( dA != nullptr );
+                expect( dB != nullptr );
+                expect( dC != nullptr );
 
                 hdAarray_[ibatch] = dA;
                 hdBarray_[ibatch] = dB;
@@ -329,7 +329,7 @@ T test_kgemm_nn_batched( int const mm,
         int const nthreads = nwarps * warpsize;
 
         cudaError_t istat_sync_start = cudaDeviceSynchronize();
-        assert( istat_sync_start == cudaSuccess );
+        expect( istat_sync_start == cudaSuccess );
 
 
         kgemm_nn_batched<T><<< batchCount, nthreads >>>( mm,nn,kk, 
@@ -341,7 +341,7 @@ T test_kgemm_nn_batched( int const mm,
                           batchCount);
 
         cudaError_t istat_sync_end = cudaDeviceSynchronize();
-        assert( istat_sync_end == cudaSuccess );
+        expect( istat_sync_end == cudaSuccess );
         }
 #else
         {

--- a/test_kgemm_nt_batched.cpp
+++ b/test_kgemm_nt_batched.cpp
@@ -23,7 +23,7 @@ void host2gpu( void *dest, void *src, size_t nbytes )
                                         src, 
                                         nbytes,  
                                         cudaMemcpyHostToDevice );
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -37,7 +37,7 @@ void gpu2host( void * dest, void * src, size_t nbytes )
                                         src,
                                         nbytes,
                                         cudaMemcpyDeviceToHost);
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -49,11 +49,11 @@ void *myalloc( size_t const nbytes ) {
               void *devPtr = nullptr;
 #ifdef USE_GPU
               cudaError_t istat = cudaMalloc( &devPtr, nbytes );
-              assert( istat == cudaSuccess );
+              expect( istat == cudaSuccess );
 #else
               devPtr = malloc( nbytes );
 #endif
-              assert( devPtr != nullptr );
+              expect( devPtr != nullptr );
               return(devPtr);
 }
 
@@ -61,7 +61,7 @@ static inline
 void myfree( void * devPtr ) {
 #ifdef USE_GPU
                 cudaError_t istat = cudaFree( devPtr);
-                assert( istat == cudaSuccess );
+                expect( istat == cudaSuccess );
 #else
                 free( devPtr );
 #endif
@@ -140,9 +140,9 @@ T test_kgemm_nt_batched( int const mm,
                 T * const B_ = new T[ldB*ncolB];
                 T * const C_ = new T[ldC*ncolC];
 
-                assert( A_ != nullptr);
-                assert( B_ != nullptr);
-                assert( C_ != nullptr);
+                expect( A_ != nullptr);
+                expect( B_ != nullptr);
+                expect( C_ != nullptr);
 
                 Aarray_[ibatch] = A_;
                 Barray_[ibatch] = B_;
@@ -210,9 +210,9 @@ T test_kgemm_nt_batched( int const mm,
                 size_t const nbytes_C = sizeof(T)*ldC*ncolC;
                 T *dC = (T *) myalloc( nbytes_C );
 
-                assert( dA != nullptr );
-                assert( dB != nullptr );
-                assert( dC != nullptr );
+                expect( dA != nullptr );
+                expect( dB != nullptr );
+                expect( dC != nullptr );
 
                 hdAarray_[ibatch] = dA;
                 hdBarray_[ibatch] = dB;
@@ -328,7 +328,7 @@ T test_kgemm_nt_batched( int const mm,
         int const nthreads = nwarps * warpsize;
 
         cudaError_t istat_sync_start = cudaDeviceSynchronize();
-        assert( istat_sync_start == cudaSuccess );
+        expect( istat_sync_start == cudaSuccess );
 
 
         kgemm_nt_batched<T><<< batchCount, nthreads >>>( mm,nn,kk, 
@@ -340,7 +340,7 @@ T test_kgemm_nt_batched( int const mm,
                           batchCount);
 
         cudaError_t istat_sync_end = cudaDeviceSynchronize();
-        assert( istat_sync_end == cudaSuccess );
+        expect( istat_sync_end == cudaSuccess );
         }
 #else
         {

--- a/test_kronmult6_batched.cpp
+++ b/test_kronmult6_batched.cpp
@@ -28,7 +28,7 @@ void host2gpu( void *dest, void *src, size_t nbytes )
                                         src, 
                                         nbytes,  
                                         cudaMemcpyHostToDevice );
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -42,7 +42,7 @@ void gpu2host( void *dest, void *src, size_t nbytes )
                                         src,
                                         nbytes,
                                         cudaMemcpyDeviceToHost);
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -54,11 +54,11 @@ void *myalloc( size_t nbytes ) {
               void *devPtr = nullptr;
 #ifdef USE_GPU
               cudaError_t istat = cudaMalloc( &devPtr, nbytes );
-              assert( istat == cudaSuccess );
+              expect( istat == cudaSuccess );
 #else
               devPtr = malloc( nbytes );
 #endif
-              assert( devPtr != nullptr );
+              expect( devPtr != nullptr );
               return(devPtr);
 }
 
@@ -66,7 +66,7 @@ static inline
 void myfree( void * devPtr ) {
 #ifdef USE_GPU
                 cudaError_t istat = cudaFree( devPtr);
-                assert( istat == cudaSuccess );
+                expect( istat == cudaSuccess );
 #else
                 free( devPtr );
 #endif
@@ -100,11 +100,11 @@ T test_kronmult_batched(  int const idim,
         T *Zarray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
         T *Warray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
 
-        assert( Aarray_ != nullptr );
-        assert( Xarray_ != nullptr );
-        assert( Yarray_ != nullptr );
-        assert( Zarray_ != nullptr );
-        assert( Warray_ != nullptr );
+        expect( Aarray_ != nullptr );
+        expect( Xarray_ != nullptr );
+        expect( Yarray_ != nullptr );
+        expect( Zarray_ != nullptr );
+        expect( Warray_ != nullptr );
 
         T *dAarray_ = (T *) myalloc( sizeof(T)*n*n*idim*batchCount);
         T *dXarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
@@ -238,14 +238,14 @@ T test_kronmult_batched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
         // -------------------------------------------
         // note important to wait for kernel to finish
         // -------------------------------------------
         cudaError_t istat = cudaDeviceSynchronize();
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
         }
 #else
 
@@ -298,7 +298,7 @@ T test_kronmult_batched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
         }

--- a/test_kronmult6_pbatched.cpp
+++ b/test_kronmult6_pbatched.cpp
@@ -28,7 +28,7 @@ void host2gpu( void *dest, void *src, size_t nbytes )
                                         src, 
                                         nbytes,  
                                         cudaMemcpyHostToDevice );
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -42,7 +42,7 @@ void gpu2host( void *dest, void *src, size_t nbytes )
                                         src,
                                         nbytes,
                                         cudaMemcpyDeviceToHost);
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -54,11 +54,11 @@ void *myalloc( size_t nbytes ) {
               void *devPtr = nullptr;
 #ifdef USE_GPU
               cudaError_t istat = cudaMalloc( &devPtr, nbytes );
-              assert( istat == cudaSuccess );
+              expect( istat == cudaSuccess );
 #else
               devPtr = malloc( nbytes );
 #endif
-              assert( devPtr != nullptr );
+              expect( devPtr != nullptr );
               return(devPtr);
 }
 
@@ -66,7 +66,7 @@ static inline
 void myfree( void * devPtr ) {
 #ifdef USE_GPU
                 cudaError_t istat = cudaFree( devPtr);
-                assert( istat == cudaSuccess );
+                expect( istat == cudaSuccess );
 #else
                 free( devPtr );
 #endif
@@ -105,14 +105,14 @@ T test_kronmult_pbatched(  int const idim,
         T *Zarray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
         T *Warray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
 
-        assert( Aarray_ != nullptr );
-        assert( Xarray_ != nullptr );
-        assert( Yarray_ != nullptr );
-        assert( Y2array_ != nullptr );
+        expect( Aarray_ != nullptr );
+        expect( Xarray_ != nullptr );
+        expect( Yarray_ != nullptr );
+        expect( Y2array_ != nullptr );
 
 
-        assert( Zarray_ != nullptr );
-        assert( Warray_ != nullptr );
+        expect( Zarray_ != nullptr );
+        expect( Warray_ != nullptr );
 
         T *dAarray_ = (T *) myalloc( sizeof(T)*n*n*idim*batchCount);
         T *dXarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
@@ -120,11 +120,11 @@ T test_kronmult_pbatched(  int const idim,
         T *dYarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
         T *dWarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
 
-        assert( dAarray_ != nullptr );
-        assert( dXarray_ != nullptr );
-        assert( dYarray_ != nullptr );
-        assert( dZarray_ != nullptr );
-        assert( dWarray_ != nullptr );
+        expect( dAarray_ != nullptr );
+        expect( dXarray_ != nullptr );
+        expect( dYarray_ != nullptr );
+        expect( dZarray_ != nullptr );
+        expect( dWarray_ != nullptr );
 
         T** pdXarray_ = (T**) malloc( sizeof(T*) * batchCount );
         T** pdYarray_ = (T**) malloc( sizeof(T*) * batchCount );
@@ -136,10 +136,10 @@ T test_kronmult_pbatched(  int const idim,
         T** dpdYarray_ = (T**) myalloc( sizeof(T*) * batchCount );
         T** dpdWarray_ = (T**) myalloc( sizeof(T*) * batchCount );
 
-        assert( dpdXarray_ != nullptr );
-        assert( dpdYarray_ != nullptr );
-        assert( dpdZarray_ != nullptr );
-        assert( dpdWarray_ != nullptr );
+        expect( dpdXarray_ != nullptr );
+        expect( dpdYarray_ != nullptr );
+        expect( dpdZarray_ != nullptr );
+        expect( dpdWarray_ != nullptr );
 
         auto Aarray = [&] (int const i, 
                            int const j, 
@@ -312,14 +312,14 @@ T test_kronmult_pbatched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
         // -------------------------------------------
         // note important to wait for kernel to finish
         // -------------------------------------------
         cudaError_t istat = cudaDeviceSynchronize();
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
         }
 #else
 
@@ -372,7 +372,7 @@ T test_kronmult_pbatched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
         }

--- a/test_kronmult6_xbatched.cpp
+++ b/test_kronmult6_xbatched.cpp
@@ -28,7 +28,7 @@ void host2gpu( void *dest, void *src, size_t nbytes )
                                         src, 
                                         nbytes,  
                                         cudaMemcpyHostToDevice );
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -42,7 +42,7 @@ void gpu2host( void *dest, void *src, size_t nbytes )
                                         src,
                                         nbytes,
                                         cudaMemcpyDeviceToHost);
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
 #else
         memcpy( dest, src, nbytes );
 #endif
@@ -54,11 +54,11 @@ void *myalloc( size_t nbytes ) {
               void *devPtr = nullptr;
 #ifdef USE_GPU
               cudaError_t istat = cudaMalloc( &devPtr, nbytes );
-              assert( istat == cudaSuccess );
+              expect( istat == cudaSuccess );
 #else
               devPtr = malloc( nbytes );
 #endif
-              assert( devPtr != nullptr );
+              expect( devPtr != nullptr );
               return(devPtr);
 }
 
@@ -66,7 +66,7 @@ static inline
 void myfree( void * devPtr ) {
 #ifdef USE_GPU
                 cudaError_t istat = cudaFree( devPtr);
-                assert( istat == cudaSuccess );
+                expect( istat == cudaSuccess );
 #else
                 free( devPtr );
 #endif
@@ -110,16 +110,16 @@ T test_kronmult_xbatched(  int const idim,
         T *Zarray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
         T *Warray_ = (T *) malloc( sizeof(T)*Xsize * batchCount);
 
-        assert( Aarray_ != nullptr );
-        assert( Aparray_ != nullptr );
+        expect( Aarray_ != nullptr );
+        expect( Aparray_ != nullptr );
 
-        assert( Xarray_ != nullptr );
-        assert( Yarray_ != nullptr );
-        assert( Y2array_ != nullptr );
+        expect( Xarray_ != nullptr );
+        expect( Yarray_ != nullptr );
+        expect( Y2array_ != nullptr );
 
 
-        assert( Zarray_ != nullptr );
-        assert( Warray_ != nullptr );
+        expect( Zarray_ != nullptr );
+        expect( Warray_ != nullptr );
 
         T *dAarray_   = (T *)  myalloc( Aarray_nbytes );
 	T **dAparray_ = (T **) myalloc( Aparray_nbytes );
@@ -129,13 +129,13 @@ T test_kronmult_xbatched(  int const idim,
         T *dYarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
         T *dWarray_ = (T *) myalloc( sizeof(T)*Xsize * batchCount );
 
-        assert( dAarray_  != nullptr );
-        assert( dAparray_ != nullptr );
+        expect( dAarray_  != nullptr );
+        expect( dAparray_ != nullptr );
 
-        assert( dXarray_ != nullptr );
-        assert( dYarray_ != nullptr );
-        assert( dZarray_ != nullptr );
-        assert( dWarray_ != nullptr );
+        expect( dXarray_ != nullptr );
+        expect( dYarray_ != nullptr );
+        expect( dZarray_ != nullptr );
+        expect( dWarray_ != nullptr );
 
         T** pdXarray_ = (T**) malloc( sizeof(T*) * batchCount );
         T** pdYarray_ = (T**) malloc( sizeof(T*) * batchCount );
@@ -147,10 +147,10 @@ T test_kronmult_xbatched(  int const idim,
         T** dpdYarray_ = (T**) myalloc( sizeof(T*) * batchCount );
         T** dpdWarray_ = (T**) myalloc( sizeof(T*) * batchCount );
 
-        assert( dpdXarray_ != nullptr );
-        assert( dpdYarray_ != nullptr );
-        assert( dpdZarray_ != nullptr );
-        assert( dpdWarray_ != nullptr );
+        expect( dpdXarray_ != nullptr );
+        expect( dpdYarray_ != nullptr );
+        expect( dpdZarray_ != nullptr );
+        expect( dpdWarray_ != nullptr );
 
         auto dAarray = [&] (int const i, 
                            int const j, 
@@ -345,14 +345,14 @@ T test_kronmult_xbatched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
         // -------------------------------------------
         // note important to wait for kernel to finish
         // -------------------------------------------
         cudaError_t istat = cudaDeviceSynchronize();
-        assert( istat == cudaSuccess );
+        expect( istat == cudaSuccess );
         }
 #else
 
@@ -405,7 +405,7 @@ T test_kronmult_xbatched(  int const idim,
                            batchCount );
             break;
          default: 
-            assert( false );
+            expect( false );
         };
 
      }


### PR DESCRIPTION
This creates an "expects" macro mirroring what was [done in the ASGarD repository](https://github.com/project-asgard/asgard/pull/362).

This should eliminate compiler warnings that crept into the Release build of ASGarD. 