### PR TITLE
setting OMP_NUM_THREADS=1 to reduce oversubscription

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@
 
         add_test (NAME ${target}
                   COMMAND ${target})
-        set_tests_properties (${target} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=1)
+        set_tests_properties (${target} PROPERTIES PROCESSORS 2 ENVIRONMENT OMP_NUM_THREADS=2)
     endmacro ()
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@
 
         add_test (NAME ${target}
                   COMMAND ${target})
+        set_tests_properties (${target} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=1)
     endmacro ()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This along with a similar change in asgard reduced the total test time from 333.07 to 174.75 seconds.