### PR TITLE
Only add warning flags if they weren't added earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,9 +144,29 @@
     target_compile_features (kron PUBLIC cxx_std_17)
     target_set_cuda (kron)
 
+    if (NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+      target_compile_options (kron
+                              PUBLIC
+                              $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+      )
+    endif()
+
+    if (NOT CMAKE_CXX_FLAGS MATCHES "-Wextra")
+      target_compile_options (kron
+                              PUBLIC
+                              $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+      )
+    endif()
+
+    if (NOT CMAKE_CXX_FLAGS MATCHES "-Wpedantic")
+      target_compile_options (kron
+                              PUBLIC
+                              $<$<COMPILE_LANGUAGE:CXX>:-Wpedantic>
+      )
+    endif()
+
     target_compile_options (kron
                             PUBLIC
-                            $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wpedantic>
                             $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options -fPIC --keep-device-functions>
     )
 


### PR DESCRIPTION
The flags `-Wall -Wextra -Wpedantic`are being added twice (once by ASGarD, once by kronmult), making it hard to suppress `-Wdtor-name` warnings that weren't consistent between clang and gcc. This checks CMAKE_CXX_FLAGS since that's what is set in ASGarD and these flags aren't duplicated in [target COMPILE_OPTIONS](https://stackoverflow.com/questions/56104607/how-to-print-current-compilation-flags-that-are-set-with-target-compile-options)